### PR TITLE
Required Config version logic wrong

### DIFF
--- a/app/views/assets/script.js
+++ b/app/views/assets/script.js
@@ -115,6 +115,9 @@ function processExtension(extension_details) {
     if (extension_details.configuration_location == 'hosted') {
         console.log('Config is Hosted');
         extension_config_service_header.closest('.accordion-item').classList.remove('disabled');
+        extension_config_service_required_header.closest('.accordion-item').classList.add('disabled');
+    } else if (extension_details.configuration_location == 'custom') {
+        extension_config_service_header.closest('.accordion-item').classList.add('disabled');
         extension_config_service_required_header.closest('.accordion-item').classList.remove('disabled');
     } else {
         console.log('Config is NOT Hosted');

--- a/app/views/interface.html
+++ b/app/views/interface.html
@@ -99,6 +99,8 @@
                         <div class="accordion-body">
                             <p>Test the <a href="https://dev.twitch.tv/docs/api/reference#get-extension-configuration-segment">Get Extension Configuration Segment</a> and <a href="https://dev.twitch.tv/docs/api/reference#set-extension-configuration-segment">Set Extension Configuration Segment</a> API</p>
 
+                            <p>If the <kbd>version</kbd> value, of the segment, matches what is set in the manfiest on the dev console for <kbd>Developer Writable Channel Segment Version</kbd> or <kbd>Broadcaster Writable Channel Segment Version</kbd> value. Then the Extension can be activated by the Broadcaster on their channel</p>
+
                             <form action="" method="post" id="config_form">
                                 <fieldset>
                                     <div class="input-group p-1">
@@ -158,6 +160,8 @@
                     <div id="extension_config_service_required" class="accordion-collapse collapse" aria-labelledby="extension_config_service_required_header" data-bs-parent="#run_accordion">
                         <div class="accordion-body">
                             <p>Test the <a href="https://dev.twitch.tv/docs/api/reference#set-extension-required-configuration">Set Extension Required Configuration</a> API</p>
+
+                            <p>If the <kbd>required_configuration</kbd> value matches what is set in the manfiest on the dev console for <kbd>Required Per Channel Configuration</kbd> value. Then the Extension can be activated by the Broadcaster on their channel</p>
 
                             <form action="" method="post" id="configreq_form">
                                 <fieldset>


### PR DESCRIPTION
Required Config version should be available to "custom" config service.

add text to both required config and config service about how version/required version based on notes in https://github.com/twitchdev/issues/issues/569

By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

A mistake when building the app due to derp ness on an extensions feature I don't use

## Description of Changes: 

- Change the disablement logic for "required config version" to correctly reflect the selected configuration mode

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_extension_tools/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
