### PR TITLE
Select correct Yes/No for bits Broadcast/InDev

### DIFF
--- a/app/views/assets/bits.js
+++ b/app/views/assets/bits.js
@@ -123,17 +123,17 @@ function cellInput(row, sku, name, value) {
         inp.setAttribute('readonly', 'readonly');
     }
 
-        inp.setAttribute('name', `${name}[${sku}]`);
-        inp.setAttribute('id', `bits_product_${name}_${sku}`);
-        inp.value = value;
+    inp.setAttribute('name', `${name}[${sku}]`);
+    inp.setAttribute('id', `bits_product_${name}_${sku}`);
+    inp.value = value;
 
     switch (name) {
         case 'in_development':
         case 'is_broadcast':
             inp = document.createElement('select');
 
-                inp.setAttribute('name', `${name}[${sku}]`);
-                inp.setAttribute('id', `bits_product_${name}_${sku}`);
+            inp.setAttribute('name', `${name}[${sku}]`);
+            inp.setAttribute('id', `bits_product_${name}_${sku}`);
 
             inp.classList.remove('form-control');
             inp.classList.add('form-select');
@@ -147,6 +147,12 @@ function cellInput(row, sku, name, value) {
             opt_no.value = 'false';
             opt_no.textContent = 'No';
             inp.append(opt_no);
+
+            if (value) {
+                opt_yes.selected = true
+            } else {
+                opt_no.selected = true
+            }
 
             break;
 


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

When fetching bits products from the API, InDev and Broadcast were always "Yes" regardless of `in_development` and `is_broadcast` being true or false. 

## Description of Changes: 

Set `selected` attribute for bits `in_development` and `is_broadcast` selection dropdown based on the value from the API

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_extension_tools/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
