### PR TITLE
Stash most recently used extension version

### DIFF
--- a/app/modules/config.js
+++ b/app/modules/config.js
@@ -143,6 +143,9 @@ module.exports = function(lib) {
         ];
         if (version) {
             params.push([ 'extension_version', version ]);
+        } else if (config['version']) {
+            // console.log('using previously used extension version: ' + config['version'])
+            params.push([ 'extension_version', config['version'] ]);
         }
         url.search = new URLSearchParams(params).toString();
 
@@ -179,6 +182,7 @@ module.exports = function(lib) {
                     client_id,
                     version: resp.data[0].version
                 });
+                store.set(`extensions.${client_id}.version`, resp.data[0].version)
                 win.webContents.send('extension_details', resp.data[0]);
                 return;
             }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

Might be a weirdness of my workflow, but I have a "dev" extension clientId that is distinct from the "prod" extension clientId. The dev version is perpetually local/hosted test v0.0.1 while the prod one goes through the lifecycle and is versioned as usual. By stashing the version ID of each extension that was most recently used it removes these extension context switch pain points:
- I'm no longer prompted to re-enter the version of the dev extension since it has no 'active' version according to the API
- I don't have to keep changing the version for the prod extension from the currently active version to the the in test/review one

## Description of Changes: 

- Save version in extension config object
- ~Fix typo with bits product UI~ removed this since I just saw #25

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_extension_tools/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
