### PR TITLE
Adjust onboarding/first setup flow

### DIFF
--- a/app/modules/config.js
+++ b/app/modules/config.js
@@ -135,10 +135,12 @@ module.exports = function(lib) {
     }
 
     function getExtensionDetails(client_id, version) {
-        let extensions = store.get('extensions');
-        let config = extensions[client_id];
+        let extensions = store.get('extensions', false);
+        if (!extensions || !extensions.hasOwnProperty(client_id)) {
+            errorMsg(`No Extension Configuration for ${client_id}`);
+            return;
+        }
         let token = sign(extensions[client_id]);
-        //console.log('Sig', token);
 
         let url = new URL('https://api.twitch.tv/helix/extensions');
         let params = [

--- a/app/views/assets/config.js
+++ b/app/views/assets/config.js
@@ -30,7 +30,7 @@ document.getElementById('id_convert_owner').addEventListener('click', (e) => {
     e.target.closest('.input-group').classList.add('loading');
 });
 
-document.getElementById('config_form').addEventListener('submit', (e) => {
+document.getElementById('create_button').addEventListener('click', (e) => {
     e.preventDefault();
 
     // validate
@@ -73,12 +73,36 @@ window.electron.config.loadedForEdit((extension) => {
     fields.forEach(field => {
         document.getElementById(field).value = extension[field] ? extension[field] : '';
     });
-    document.getElementById('create_button').value = "Edit";
+    document.getElementById('create_button').value = "Edit Extension Configuration";
+    // and show modal
+    let modal = new bootstrap.Modal(document.getElementById('add_new_extension_modal'));
+    modal.show();
 });
 
 window.electron.config.extensions((data) => {
     let { extensions, active_client_id } = data;
     //console.log('extensions', active_client_id, extensions);
+
+    // draw
+    let dropdown = document.getElementById('extension_select');
+    dropdown.textContent = '';
+    let el = document.getElementById('existing_extensions').getElementsByTagName('tbody')[0];
+    el.textContent = '';
+
+    if (!extensions || Object.keys(extensions).length == 0) {
+        let row = el.insertRow();
+        var cell = row.insertCell();
+        cell.textContent = 'You have no Extensions Configured. Click "Add New Extension Configuration" to add a configuration';
+        cell.classList.add('text-center');
+        cell.classList.add('text-danger');
+        cell.setAttribute('colspan', 4);
+        // and force nudge
+        let modal = new bootstrap.Modal(document.getElementById('add_new_extension_modal'));
+        modal.show();
+        // extra nudge
+        errorMsg('You have no Extension Configurations. Add one to continue');
+        return;
+    }
 
     // reset entry form
     let inputs = document.getElementById('config_form').getElementsByTagName('input');
@@ -87,13 +111,7 @@ window.electron.config.extensions((data) => {
             inputs[x].value = '';
         }
     }
-    document.getElementById('create_button').value = "Create";
-
-    // draw
-    let dropdown = document.getElementById('extension_select');
-    dropdown.textContent = '';
-    let el = document.getElementById('existing_extensions').getElementsByTagName('tbody')[0];
-    el.textContent = '';
+    document.getElementById('create_button').value = "Create Extension Configuration";
 
     for (var ref in extensions) {
         let row = el.insertRow();

--- a/app/views/interface.html
+++ b/app/views/interface.html
@@ -22,7 +22,10 @@
     </ul>
     <div class="tab-content">
         <div class="tab-pane p-3 show active" id="config" role="tabpanel" aria-labelledby="config-tab">
-            <a href="https://dev.twitch.tv/console/extensions" class="btn btn-outline-primary float-end">Dev Console</a>
+            <div class="btn-group float-end">
+                <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#add_new_extension_modal">Add New Extension Configuration</button>
+                <a href="https://dev.twitch.tv/console/extensions" class="btn btn-outline-primary">Dev Console</a>
+            </div>
             <h3>Configuration</h3>
 
             <table id="existing_extensions" class="table">
@@ -37,45 +40,7 @@
                 <tbody></tbody>
             </table>
 
-            <form action="" method="post" id="config_form">
-                <fieldset>
-                    <legend>Add New Extension</legend>
-
-                    <p>If the ClientID already exists in the local configuration, the configuration will be overwritten</p>
-
-                    <div class="input-group p-1">
-                        <label class="input-group-text" for="name">Name</label>
-                        <input type="text" name="name" id="name" value="" class="form-control" />
-                    </div>
-                    <div class="help-text">Can use your own name doesn't need to be the real name</div>
-                    <div class="input-group p-1">
-                        <label class="input-group-text" for="client_id">Extension Client ID</label>
-                        <input type="text" name="client_id" id="client_id" value="" class="form-control" />
-                    </div>
-                    <div class="input-group p-1">
-                        <label class="input-group-text" for="extension_secret">Extension Secret</label>
-                        <input type="text" name="extension_secret" id="extension_secret" value="" class="form-control" />
-                    </div>
-                    <div class="help-text">From Extension Client Configuration -> Extension Secrets. The Extension Shared Secret for signing tokens.</div>
-
-                    <div class="input-group p-1">
-                        <label class="input-group-text" for="client_secret">Twitch API Client Secret</label>
-                        <input type="text" name="client_secret" id="client_secret" value="" class="form-control" />
-                    </div>
-                    <div class="help-text">(Optional) From Twitch API Client Secret -> Generate Secret. Optional, only needed for Bits management and Login to ID lookups</div>
-
-
-                    <div class="input-group p-1">
-                        <label class="input-group-text" for="user_id">Owner Twitch ID</label>
-                        <input type="text" name="user_id" id="user_id" value="" class="form-control" />
-                        <span class="input-group-text btn btn-outline-primary" id="id_convert_owner">Convert to ID</span>
-                    </div>
-                    <div class="input-group p-1">
-                        <input type="submit" class="btn btn-primary" id="create_button" value="Create" />
-                    </div>
-                    <div class="help-text">Data is stored locally unencrypted - <kbd>%appdata%/BarryCarlyonTwitchExtensionTools/config.json</kbd></div>
-                </fieldset>
-            </form>
+            <div class="help-text">Extension configurations (Client Secrets and generated App Access Tokens) are stored locally unencrypted in the following file <kbd>%appdata%/BarryCarlyonTwitchExtensionTools/config.json</kbd></div>
         </div>
         <div class="tab-pane p-3" id="run" role="tabpanel" aria-labelledby="run-tab">
             <div class="float-end">
@@ -474,6 +439,55 @@
                     </div>
                 </div>
 
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="add_new_extension_modal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-xl">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="staticBackdropLabel">Extension Configuration</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form action="" method="post" id="config_form">
+                        <fieldset>
+                            <a href="https://dev.twitch.tv/console/extensions" class="btn btn-outline-primary float-end">Dev Console</a>
+                            <p>If the ClientID already exists in the local configuration, the configuration will be overwritten</p>
+
+                            <div class="input-group p-1">
+                                <label class="input-group-text" for="name">Name</label>
+                                <input type="text" name="name" id="name" value="" class="form-control" />
+                            </div>
+                            <div class="help-text">Can use your own name doesn't need to be the real name</div>
+                            <div class="input-group p-1">
+                                <label class="input-group-text" for="client_id">Extension Client ID</label>
+                                <input type="text" name="client_id" id="client_id" value="" class="form-control" />
+                            </div>
+                            <div class="input-group p-1">
+                                <label class="input-group-text" for="extension_secret">Extension Secret</label>
+                                <input type="text" name="extension_secret" id="extension_secret" value="" class="form-control" />
+                            </div>
+                            <div class="help-text">From Extension Client Configuration -> Extension Secrets. The Extension Shared Secret for signing tokens.</div>
+
+                            <div class="input-group p-1">
+                                <label class="input-group-text" for="client_secret">Twitch API Client Secret</label>
+                                <input type="text" name="client_secret" id="client_secret" value="" class="form-control" />
+                            </div>
+                            <div class="help-text">(Optional) From Twitch API Client Secret -> Generate Secret. Optional, only needed for Bits management and Login to ID lookups</div>
+
+                            <div class="input-group p-1">
+                                <label class="input-group-text" for="user_id">Owner Twitch ID</label>
+                                <input type="text" name="user_id" id="user_id" value="" class="form-control" />
+                                <span class="input-group-text btn btn-outline-primary" id="id_convert_owner">Convert to ID</span>
+                            </div>
+                        </fieldset>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <input type="submit" class="btn btn-primary" id="create_button" value="Create Extension Configuration" />
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Move the "add new extension" to a modal so it's not always there in your face.
Fix the "trigger" to save an extension configuration

Tidy getExtensionDetails a little

By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

Please include a description of the problem or feature this PR is addressing.

## Description of Changes: 

- Move add/edit Extension Details to a modal so the landing page is a little cleaner
- If no extensions the table _says_ there is no extension
- On "first setup" auto prompt the add new extension modal

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_extension_tools/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
