### PR TITLE
Fix a HTML ID collision.

### DIFF
--- a/app/views/assets/config.js
+++ b/app/views/assets/config.js
@@ -80,6 +80,10 @@ window.electron.config.loadedForEdit((extension) => {
 });
 
 window.electron.config.extensions((data) => {
+    // dismiss dialog
+    let modal = bootstrap.Modal.getOrCreateInstance('#add_new_extension_modal');
+    modal.hide();
+
     let { extensions, active_client_id } = data;
     //console.log('extensions', active_client_id, extensions);
 

--- a/app/views/assets/functions.js
+++ b/app/views/assets/functions.js
@@ -65,10 +65,10 @@ document.getElementById('config_segment').addEventListener('change', (e) => {
 });
 document.getElementById('config_broadcaster_id').setAttribute('readonly', 'readonly');
 
-document.getElementById('config_form').addEventListener('submit', (e) => {
+document.getElementById('extension_config_service_form').addEventListener('submit', (e) => {
     e.preventDefault();
 });
-document.getElementById('config_fetch').addEventListener('click', (e) => {
+document.getElementById('extension_config_service_fetch').addEventListener('click', (e) => {
     window.electron.extensionAPI(
         'getconfiguration',
         {
@@ -78,7 +78,7 @@ document.getElementById('config_fetch').addEventListener('click', (e) => {
         }
     );
 });
-document.getElementById('config_write').addEventListener('click', (e) => {
+document.getElementById('extension_config_service_write').addEventListener('click', (e) => {
     let content = document.getElementById('config_content').value;
     if (document.getElementById('config_content_json').checked) {
         // tidy up

--- a/app/views/interface.html
+++ b/app/views/interface.html
@@ -67,7 +67,7 @@
 
                             <p>If the <kbd>version</kbd> value, of the segment, matches what is set in the manifest on the dev console for <kbd>Developer Writable Channel Segment Version</kbd> or <kbd>Broadcaster Writable Channel Segment Version</kbd> value. Then the Extension can be activated by the Broadcaster on their channel</p>
 
-                            <form action="" method="post" id="config_form">
+                            <form action="" method="post" id="extension_config_service_form">
                                 <fieldset>
                                     <div class="input-group p-1">
                                         <label class="input-group-text" for="config_extension_id">extension_id</label>
@@ -109,8 +109,8 @@
                                     <div class="help-text">Optional Version field. Used with <a href="https://dev.twitch.tv/docs/api/reference#set-extension-required-configuration">Set Extension Required Configuration</a> to block activation until (re)configured</div>
 
                                     <div class="btn-group p-1 float-end">
-                                        <input type="button" class="btn btn-outline-primary" id="config_fetch" value="Fetch Config" />
-                                        <input type="button" class="btn btn-outline-danger" id="config_write" value="Write Config" />
+                                        <input type="button" class="btn btn-outline-primary" id="extension_config_service_fetch" value="Fetch Config" />
+                                        <input type="button" class="btn btn-outline-danger" id="extension_config_service_write" value="Write Config" />
                                     </div>
                                 </fieldset>
                             </form>


### PR DESCRIPTION
Auto dismiss the edit extension dialog when saving an edit to an extension

By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

ID collision in the HTML needs a tweak

## Description of Changes: 

- Fix HTML ID collision
- Fix related JS events/triggers
- Auto dismiss the Edit Extension dialog when you edit/save a configuration

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_extension_tools/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
