### PR TITLE
Swap the selects in the bits control to switches

### DIFF
--- a/app/views/assets/bits.js
+++ b/app/views/assets/bits.js
@@ -150,6 +150,7 @@ function cellInput(row, sku, name, value) {
             break;
 
         case 'amount':
+            inp.classList.add('text-end');
             inp.setAttribute('type', 'number');
 
             inp.setAttribute('step', '1');

--- a/app/views/interface.html
+++ b/app/views/interface.html
@@ -342,7 +342,7 @@
                                                     <input type="text" name="bits_product_new_sku" id="bits_product_new_sku" placeholder="New Product Sku" class="form-control"/>
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="bits_product_new_cost" id="bits_product_new_cost" min="1" max="10000" length="5" value="1" class="form-control"/>
+                                                    <input type="number" name="bits_product_new_cost" id="bits_product_new_cost" min="1" max="10000" length="5" value="1" class="form-control text-end"/>
                                                 </td>
                                                 <td>
                                                     <div class="form-check form-switch">


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

if you have a not very wide interface, the selects for broadcast and dev are cut off due ot the browser chrome.

## Description of Changes: 

- Change the two selects in the bits table/form to switches instead for new products
- Change the two selects for editing products
- Revise the association JS code from Value checks to checked checked since it's a checkbox now

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_extension_tools/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
