### PR TITLE
Change the dropdown to show the name of the current extension

### DIFF
--- a/app/views/assets/config.js
+++ b/app/views/assets/config.js
@@ -277,6 +277,7 @@ function markDropdown(client_id) {
         if (client_id || client_id == '') {
             if (items[x].getAttribute('data-client_id') == client_id) {
                 items[x].classList.add('bg-primary');
+                select_active_extension.textContent = items[x].textContent;
             }
         }
     }

--- a/app/views/interface.html
+++ b/app/views/interface.html
@@ -17,8 +17,8 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" id="dropdown01" href="#" role="button" aria-expanded="false">Select Active Extension</a>
-                        <ul class="dropdown-menu" aria-labelledby="dropdown01" id="extension_select"></ul>
+                        <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" id="select_active_extension" href="#" role="button" aria-expanded="false">Select Active Extension</a>
+                        <ul class="dropdown-menu" aria-labelledby="select_active_extension" id="extension_select"></ul>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the WTFPL license.

## Problem/Feature

Improve UI Clairty, puts the title of the extension currently being controlled in the nav

## Description of Changes: 

- the extension switcher shows the name of the current extension, if any

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
- [x] I don't give a [F*ck](https://github.com/BarryCarlyon/twitch_extension_tools/blob/main/LICENSE) - Do What The F*ck You Want To with my Submission
